### PR TITLE
Ignore taiki-e/install-action pinning updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,5 +12,13 @@
   "timezone": "America/Chicago",
   "schedule": [
     "before 4am on Friday"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["taiki-e/install-action"],
+      "pin": {
+        "enabled": false
+      }
+    }
   ]
 }


### PR DESCRIPTION
This PR adds a package rule to disable pinning updates for taiki-e/install-action while still allowing version updates.