### PR TITLE
Require 7-day minimum release age for dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,6 +14,7 @@
     "enabled": true
   },
   "prHourlyLimit": 10,
+  "minimumReleaseAge": "7 days",
   "timezone": "America/Chicago",
   "schedule": [
     "* * * * 5"


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge: "7 days"` to the shared Renovate config so updates are only proposed once a release has been public for a full week.

## Why
- Protects consumers from versions that get yanked, hotfixed, or exposed as compromised shortly after publish.
- Pairs well with the existing automerge rules — updates that do flow through have had time to be vetted by the ecosystem.

## Test plan
- [ ] Next Renovate run on a consumer repo shows pending updates deferred until they are ≥7 days old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that delays dependency update PRs; primary impact is slower uptake of new versions (including security fixes) by up to 7 days.
> 
> **Overview**
> Adds `minimumReleaseAge: "7 days"` to the shared Renovate config so dependency update PRs (including automergeable ones) are only created after a release has been available for at least a week.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faef6ba0934bfa8c4be5706341f0491c63264d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->