### PR TITLE
Apply minimumReleaseAge to lockFileMaintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,7 +11,8 @@
     "abandonments:recommended"
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "minimumReleaseAge": "7 days"
   },
   "prHourlyLimit": 10,
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## Summary
- Follow-up to #4: the top-level `minimumReleaseAge` does not cascade into `lockFileMaintenance`, so the Friday maintenance run could still upgrade dependencies to versions <7 days old.
- Sets `minimumReleaseAge: "7 days"` inside the `lockFileMaintenance` block so lockfile bumps honor the same stability window as regular update PRs.

## Test plan
- [ ] Next Friday lockfile maintenance PR only pulls in versions that are ≥7 days old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts Renovate behavior for lockfile maintenance updates; main risk is delaying lockfile bumps if the release-age window is too strict.
> 
> **Overview**
> Ensures Renovate `lockFileMaintenance` runs honor the same `minimumReleaseAge` (7 days) as regular dependency update PRs by setting `lockFileMaintenance.minimumReleaseAge` in `default.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f074a2a804af8343d41548efaced07dff179bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->