### PR TITLE
fix: skip release age for owned packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "cloneSubmodules": true,
   "automerge": true,
+  "cloneSubmodules": true,
   "dependencyDashboard": true,
   "extends": [
     "config:recommended",
@@ -14,26 +14,129 @@
     "enabled": true,
     "minimumReleaseAge": "7 days"
   },
-  "prHourlyLimit": 10,
   "minimumReleaseAge": "7 days",
-  "timezone": "America/Chicago",
-  "schedule": [
-    "* * * * 5"
-  ],
   "packageRules": [
     {
+      "automerge": true,
       "description": "Automerge non-major updates",
-      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
-      "automerge": true
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "lockFileMaintenance"
+      ]
     },
     {
-      "matchPackageNames": ["taiki-e/install-action"],
+      "description": "Do not delay jdx-owned crates",
+      "matchDatasources": [
+        "crate"
+      ],
+      "matchPackageNames": [
+        "aqua-registry",
+        "aube",
+        "aube-codes",
+        "aube-linker",
+        "aube-lockfile",
+        "aube-manifest",
+        "aube-registry",
+        "aube-resolver",
+        "aube-runtime",
+        "aube-scripts",
+        "aube-settings",
+        "aube-store",
+        "aube-util",
+        "aube-workspace",
+        "clap-sort",
+        "clap_usage",
+        "clonedir",
+        "clonedir_lib",
+        "clx",
+        "communique",
+        "deepmerge",
+        "deepmerge-derive",
+        "demand",
+        "ensembler",
+        "entrepot",
+        "expr-lang",
+        "fnox",
+        "fnox-core",
+        "garni",
+        "hk",
+        "jdx-csv-lint",
+        "mise",
+        "mise-interactive-config",
+        "mise-sigstore",
+        "nd",
+        "nd_lib",
+        "osv-bloom",
+        "osv-bloom-build",
+        "pitchfork-cli",
+        "pklr",
+        "quick-bool",
+        "rpkl-jdx",
+        "rtx-cli",
+        "sigstore-verification",
+        "spinners-jdxcode",
+        "usage-cli",
+        "usage-lib",
+        "usage_example_rust_clap",
+        "vfox",
+        "wait-for-gh-rate-limit",
+        "xx"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Do not delay jdx-owned CLI tool releases",
+      "matchPackageNames": [
+        "aqua:jdx/aube",
+        "aqua:jdx/hk",
+        "aqua:jdx/pitchfork",
+        "aqua:jdx/usage",
+        "aube",
+        "cargo:aube",
+        "communique",
+        "fnox",
+        "ghcr.io/jdx/mise",
+        "github:jdx/aube",
+        "github:jdx/communique",
+        "github:jdx/fnox",
+        "github:jdx/wait-for-gh-rate-limit",
+        "hk",
+        "jdx/aube",
+        "jdx/communique",
+        "jdx/fnox",
+        "jdx/hk",
+        "jdx/mise",
+        "jdx/pitchfork",
+        "jdx/ubi",
+        "jdx/usage",
+        "jdx/wait-for-gh-rate-limit",
+        "mise",
+        "pitchfork",
+        "ubi",
+        "usage",
+        "wait-for-gh-rate-limit"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "matchPackageNames": [
+        "taiki-e/install-action"
+      ],
       "pinDigests": false
     },
     {
       "description": "Group lockfile maintenance updates",
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "groupName": "lockfile maintenance"
+      "groupName": "lockfile maintenance",
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ]
     }
-  ]
+  ],
+  "prHourlyLimit": 10,
+  "schedule": [
+    "* * * * 5"
+  ],
+  "timezone": "America/Chicago"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["local>jdx/renovate-config"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>jdx/renovate-config"
+  ]
 }


### PR DESCRIPTION
## Summary
- disable minimumReleaseAge for jdx-owned crates published on crates.io
- disable minimumReleaseAge for jdx-owned CLI tool release package names used through Renovate/mise/GitHub/Docker
- apply the repo's JSON formatting to renovate.json/default.json

## Validation
- jq -e . default.json renovate.json
- pre-commit run --all-files
- npx --yes --package renovate renovate-config-validator default.json

Renovate documents package-rule `minimumReleaseAge: null` as the opt-out for minimum release age checks: https://docs.renovatebot.com/key-concepts/minimum-release-age/#how-do-i-opt-out-dependencies-from-minimum-release-age-checks

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate configuration only; no runtime or security logic, though owned packages will get update PRs sooner than other deps.
> 
> **Overview**
> Adds two **Renovate `packageRules`** in `default.json` that set **`minimumReleaseAge: null`**, overriding the repo-wide **7-day** wait so owned dependencies can be updated immediately.
> 
> One rule targets **crates.io** packages (`matchDatasources: crate`) with a long allowlist of **jdx-owned crate names**. The second covers **CLI/tool releases** across **aqua**, **GitHub**, **cargo**, **Docker (`ghcr.io`)**, and related **package name** variants (e.g. `mise`, `hk`, `usage`, `fnox`).
> 
> **`renovate.json`** and **`default.json`** also get **JSON formatting** only (multi-line arrays, key reordering); behavior like **automerge**, **schedule**, and **`prHourlyLimit`** is unchanged aside from the new rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0decd3c7716553e1932886666d25a4a72b4512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->