### PR TITLE
fix: regenerate mise npm lockfiles

### DIFF
--- a/default.json
+++ b/default.json
@@ -127,6 +127,33 @@
       "pinDigests": false
     },
     {
+      "description": "Regenerate mise lockfiles for npm-backed mise tools with Node/npm available",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchDatasources": [
+        "npm"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "mise lock"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "mise.lock",
+          "mise.*.lock",
+          "**/mise.lock",
+          "**/mise.*.lock"
+        ],
+        "installTools": {
+          "mise": {},
+          "node": {},
+          "npm": {}
+        },
+        "workingDirTemplate": "{{{packageFileDir}}}"
+      }
+    },
+    {
       "description": "Group lockfile maintenance updates",
       "groupName": "lockfile maintenance",
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary
- add a focused post-upgrade fallback for mise-managed npm dependencies
- install mise/node/npm for the fallback command before running `mise lock`
- include mise lockfiles in the post-upgrade file filters so Renovate commits the regenerated artifact

## Notes
This relies on the Renovate runner allowing the final command via global `allowedCommands`, e.g. `^mise lock$`. The built-in mise artifact updater still requires global `allowedUnsafeExecutions` to include `mise`.

## Validation
- `jq . default.json`
- `mise x node@24 -- npx --yes --package renovate renovate-config-validator default.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration change; runtime app behavior is unchanged, though runner must allow `mise lock` and related tool installs.
> 
> **Overview**
> Adds a Renovate **package rule** so **mise** manager updates from **npm** run a post-upgrade **`mise lock`** in the package directory, with **mise**, **node**, and **npm** installed first.
> 
> The task runs in **branch** execution mode and limits committed files to **`mise.lock`** / **`mise.*.lock`** patterns so Renovate PRs include regenerated lock artifacts instead of only manifest bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440d1f7c5dfb46d045de5eff1460a3f34b82e473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->