### PR TITLE
feat: keep aube-lock.yaml in sync on Renovate branches

### DIFF
--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -1,0 +1,78 @@
+name: aube-lock
+
+# Reusable workflow: regenerates aube-lock.yaml on Renovate branches.
+#
+# Renovate has no native aube manager, so its npm manager updates
+# package.json but leaves aube-lock.yaml stale, breaking CI runs of
+# `aube install --frozen-lockfile`. postUpgradeTasks would fix this but
+# only run on self-hosted Renovate, not the Mend hosted app. This
+# workflow closes the gap: it runs on pushes to renovate/** branches,
+# regenerates the lockfile, and commits it back.
+#
+# Caller repos add (with `permissions: contents: write`):
+#
+#   name: aube-lock
+#   on:
+#     push:
+#       branches: ["renovate/**"]
+#   permissions:
+#     contents: write
+#   jobs:
+#     aube-lock:
+#       uses: jdx/renovate-config/.github/workflows/aube-lock.yml@main
+#       secrets: inherit
+#
+# Secrets (optional but recommended): AUBE_LOCK_APP_ID and
+# AUBE_LOCK_APP_PRIVATE_KEY for a GitHub App with contents:write. When
+# present, the lockfile commit is pushed with a short-lived App token so
+# it retriggers CI on the Renovate branch. Without them the workflow
+# falls back to GITHUB_TOKEN, which still fixes the lockfile but does
+# NOT retrigger workflows (GitHub's recursion guard), so the PR's checks
+# must be re-run manually.
+#
+# The committer author must be listed in gitIgnoredAuthors in the shared
+# Renovate config (see default.json) so Renovate keeps rebasing branches
+# we have committed to.
+
+on:
+  workflow_call: {}
+
+jobs:
+  aube-lock:
+    # Only react to Renovate's own pushes; our fix-up push (App token)
+    # has a different actor, so this also prevents self-retriggering.
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: aube-lock-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Generate app token
+        id: app-token
+        if: ${{ secrets.AUBE_LOCK_APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUBE_LOCK_APP_ID }}
+          private-key: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - name: Regenerate aube-lock.yaml
+        run: |
+          if [ ! -f aube-lock.yaml ]; then
+            echo "no aube-lock.yaml in this repo, nothing to do"
+            exit 0
+          fi
+          mise x -- aube install --no-frozen-lockfile
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- aube-lock.yaml; then
+            echo "aube-lock.yaml already up to date"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add aube-lock.yaml
+          git commit -m 'chore(deps): regenerate aube-lock.yaml'
+          git push

--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -19,8 +19,10 @@ name: aube-lock
 #     contents: write
 #   jobs:
 #     aube-lock:
-#       uses: jdx/renovate-config/.github/workflows/aube-lock.yml@main
-#       secrets: inherit
+#       uses: jdx/renovate-config/.github/workflows/aube-lock.yml@<sha>
+#       secrets:
+#         AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
+#         AUBE_LOCK_APP_PRIVATE_KEY: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}
 #
 # Secrets (optional but recommended): AUBE_LOCK_APP_ID and
 # AUBE_LOCK_APP_PRIVATE_KEY for a GitHub App with contents:write. When
@@ -35,28 +37,41 @@ name: aube-lock
 # we have committed to.
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      AUBE_LOCK_APP_ID:
+        description: GitHub App ID used to push lockfile commits (optional)
+        required: false
+      AUBE_LOCK_APP_PRIVATE_KEY:
+        description: GitHub App private key used to push lockfile commits (optional)
+        required: false
 
 jobs:
   aube-lock:
-    # Only react to Renovate's own pushes; our fix-up push (App token)
-    # has a different actor, so this also prevents self-retriggering.
-    if: github.actor == 'renovate[bot]'
+    # Only react to Renovate's own pushes (checked by the event sender's
+    # immutable numeric id, not a spoofable login); our fix-up push has a
+    # different sender, so this also prevents self-retriggering.
+    if: github.event.sender.id == 29139614 # renovate[bot]
     runs-on: ubuntu-latest
     concurrency:
       group: aube-lock-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      # secrets context is not allowed in step-level `if`; the app id is
+      # not sensitive, so surface it via env for the presence check
+      AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
     steps:
       - name: Generate app token
         id: app-token
-        if: ${{ secrets.AUBE_LOCK_APP_ID != '' }}
+        if: env.AUBE_LOCK_APP_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.AUBE_LOCK_APP_ID }}
           private-key: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}
+          permission-contents: write
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ steps.app-token.outputs.token || github.token }}
+          persist-credentials: false
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       - name: Regenerate aube-lock.yaml
         run: |
@@ -66,8 +81,12 @@ jobs:
           fi
           mise x -- aube install --no-frozen-lockfile
       - name: Commit and push if changed
+        env:
+          PUSH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
         run: |
-          if git diff --quiet -- aube-lock.yaml; then
+          if ! [ -f aube-lock.yaml ] || git diff --quiet -- aube-lock.yaml; then
             echo "aube-lock.yaml already up to date"
             exit 0
           fi
@@ -75,4 +94,4 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add aube-lock.yaml
           git commit -m 'chore(deps): regenerate aube-lock.yaml'
-          git push
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"

--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -57,13 +57,14 @@ jobs:
       group: aube-lock-${{ github.ref }}
       cancel-in-progress: true
     env:
-      # secrets context is not allowed in step-level `if`; the app id is
-      # not sensitive, so surface it via env for the presence check
-      AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
+      # secrets context is not allowed in step-level `if`; surface the
+      # presence check via env. Both secrets must be set, otherwise fall
+      # back to GITHUB_TOKEN instead of failing the token step
+      AUBE_LOCK_HAS_APP: ${{ secrets.AUBE_LOCK_APP_ID != '' && secrets.AUBE_LOCK_APP_PRIVATE_KEY != '' }}
     steps:
       - name: Generate app token
         id: app-token
-        if: env.AUBE_LOCK_APP_ID != ''
+        if: env.AUBE_LOCK_HAS_APP == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.AUBE_LOCK_APP_ID }}
@@ -73,25 +74,31 @@ jobs:
         with:
           persist-credentials: false
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-      - name: Regenerate aube-lock.yaml
+      - name: Regenerate aube lockfiles
+        # regenerate every tracked aube-lock.yaml, not just the root one:
+        # repos like jdx/hk keep a nested docs/aube-lock.yaml alongside the
+        # root lockfile. the git pathspec '*aube-lock.yaml' matches both.
         run: |
-          if [ ! -f aube-lock.yaml ]; then
+          if [ -z "$(git ls-files -- '*aube-lock.yaml')" ]; then
             echo "no aube-lock.yaml in this repo, nothing to do"
             exit 0
           fi
-          mise x -- aube install --no-frozen-lockfile
+          for d in $(git ls-files -- '*aube-lock.yaml' | xargs -n1 dirname); do
+            echo "regenerating aube-lock.yaml in $d"
+            (cd "$d" && mise x -- aube install --no-frozen-lockfile) || exit 1
+          done
       - name: Commit and push if changed
         env:
           PUSH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
         run: |
-          if ! [ -f aube-lock.yaml ] || git diff --quiet -- aube-lock.yaml; then
-            echo "aube-lock.yaml already up to date"
+          if git diff --quiet -- '*aube-lock.yaml'; then
+            echo "aube lockfiles already up to date"
             exit 0
           fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add aube-lock.yaml
+          git add -- '*aube-lock.yaml'
           git commit -m 'chore(deps): regenerate aube-lock.yaml'
           git push "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"

--- a/default.json
+++ b/default.json
@@ -160,7 +160,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "test -f aube-lock.yaml && mise x -- aube install --no-frozen-lockfile || true"
+          "if [ -f aube-lock.yaml ]; then mise x -- aube install --no-frozen-lockfile; fi"
         ],
         "executionMode": "branch",
         "fileFilters": [

--- a/default.json
+++ b/default.json
@@ -10,6 +10,9 @@
     ":configMigration",
     "abandonments:recommended"
   ],
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "minimumReleaseAge": "7 days"

--- a/default.json
+++ b/default.json
@@ -154,6 +154,25 @@
       }
     },
     {
+      "description": "Regenerate aube-lock.yaml when npm dependencies change (aube projects only)",
+      "matchManagers": [
+        "npm"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "test -f aube-lock.yaml && mise x -- aube install --no-frozen-lockfile || true"
+        ],
+        "executionMode": "branch",
+        "fileFilters": [
+          "aube-lock.yaml",
+          "**/aube-lock.yaml"
+        ],
+        "installTools": {
+          "mise": {}
+        }
+      }
+    },
+    {
       "description": "Group lockfile maintenance updates",
       "groupName": "lockfile maintenance",
       "matchUpdateTypes": [

--- a/default.json
+++ b/default.json
@@ -163,7 +163,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "if [ -f aube-lock.yaml ]; then mise x -- aube install --no-frozen-lockfile; fi"
+          "for d in $(git ls-files -- '*aube-lock.yaml' | xargs -n1 dirname); do (cd \"$d\" && mise x -- aube install --no-frozen-lockfile) || exit 1; done"
         ],
         "executionMode": "branch",
         "fileFilters": [

--- a/default.json
+++ b/default.json
@@ -163,7 +163,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "for d in $(git ls-files -- '*aube-lock.yaml' | xargs -n1 dirname); do (cd \"$d\" && mise x -- aube install --no-frozen-lockfile) || exit 1; done"
+          "git ls-files -- '*aube-lock.yaml' | while read -r f; do (cd \"$(dirname \"$f\")\" && mise x -- aube install --no-frozen-lockfile) || exit 1; done"
         ],
         "executionMode": "branch",
         "fileFilters": [


### PR DESCRIPTION
## Problem

Renovate has **no native aube manager**. Its `npm` manager updates `package.json` but leaves `aube-lock.yaml` stale, so CI's `aube install --frozen-lockfile` fails on every JS bump — e.g. [jdx/hk#1084](https://github.com/jdx/hk/pull/1084) (typescript v6→v7), fixed by hand.

## What this PR does

**1. Reusable `aube-lock` workflow** (`.github/workflows/aube-lock.yml`) — the fix that actually runs on the Mend hosted app. `postUpgradeTasks` are self-hosted-only (the hosted app ignores them — which is also why the existing `mise lock` postUpgradeTask never fires). Instead, repos call this workflow on pushes to `renovate/**` branches; it regenerates `aube-lock.yaml` and commits it back. Caller (per aube repo):

```yaml
name: aube-lock
on:
  push:
    branches: ["renovate/**"]
permissions:
  contents: write
jobs:
  aube-lock:
    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@main
    secrets: inherit
```

- Runs only when the push actor is `renovate[bot]`; no-ops in repos without `aube-lock.yaml`.
- Uses `jdx/mise-action` + `mise x -- aube install --no-frozen-lockfile`, mirroring existing CI. Actions pinned by SHA.
- No third-party apps (deliberately avoids autofix.ci).

**2. GitHub App token (recommended, optional)** — pushes made with `GITHUB_TOKEN` don't retrigger workflows (GitHub's recursion guard), so the PR would stay red until checks are re-run manually. If org secrets `AUBE_LOCK_APP_ID` / `AUBE_LOCK_APP_PRIVATE_KEY` exist (a GitHub App with only `contents: write`, installed on aube repos), the push uses a short-lived App token and CI retriggers automatically. Without the secrets it degrades gracefully to `GITHUB_TOKEN`.

**3. `gitIgnoredAuthors`** — adds `github-actions[bot]`'s email so Renovate keeps rebasing/updating branches the workflow has committed to (same reason mise-action's config ignores autofix.ci's bot).

**4. `postUpgradeTasks` rule for aube** — inert on the hosted app, but correct and consistent with the existing mise-lock rule if Renovate is ever self-hosted. Guarded by `if [ -f aube-lock.yaml ]` so it's a no-op in non-aube repos.

## Setup checklist (after merge)

- [ ] Create a GitHub App (`contents: write` only), install it on aube-using repos
- [ ] Add org secrets `AUBE_LOCK_APP_ID` and `AUBE_LOCK_APP_PRIVATE_KEY`
- [ ] Add the caller workflow to each aube repo (PR for hk: see linked PR below)

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Renovate shared config and a new optional caller workflow; no application runtime or auth logic in consuming apps beyond optional GitHub App push secrets.
> 
> **Overview**
> Adds automation so **aube** lockfiles stay aligned when Renovate bumps npm deps, avoiding CI failures on `aube install --frozen-lockfile`.
> 
> Introduces a **reusable `aube-lock` GitHub Actions workflow** that consumer repos invoke on `renovate/**` pushes. It only runs for Renovate’s bot sender (to avoid loops), regenerates every tracked `*aube-lock.yaml` via `mise x -- aube install --no-frozen-lockfile`, and commits/pushes updates. Optional org secrets enable a **GitHub App token** for pushes so workflows re-run; without them it falls back to `GITHUB_TOKEN` (lockfile still updates, checks may need a manual re-run).
> 
> Updates shared Renovate config with **`gitIgnoredAuthors`** for `github-actions[bot]` so Renovate keeps updating branches the workflow touched, and adds an **npm `postUpgradeTasks` rule** that runs the same lockfile regeneration (mainly for self-hosted Renovate; Mend hosted app ignores these tasks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c47679710b480fd9eba48dcbb46cb18b5b584c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->