### PR TITLE
fix: drop aube postUpgradeTasks rule in favor of the workflow

### DIFF
--- a/default.json
+++ b/default.json
@@ -157,25 +157,6 @@
       }
     },
     {
-      "description": "Regenerate aube-lock.yaml when npm dependencies change (aube projects only)",
-      "matchManagers": [
-        "npm"
-      ],
-      "postUpgradeTasks": {
-        "commands": [
-          "git ls-files -- '*aube-lock.yaml' | while read -r f; do (cd \"$(dirname \"$f\")\" && mise x -- aube install --no-frozen-lockfile) || exit 1; done"
-        ],
-        "executionMode": "branch",
-        "fileFilters": [
-          "aube-lock.yaml",
-          "**/aube-lock.yaml"
-        ],
-        "installTools": {
-          "mise": {}
-        }
-      }
-    },
-    {
       "description": "Group lockfile maintenance updates",
       "groupName": "lockfile maintenance",
       "matchUpdateTypes": [


### PR DESCRIPTION
## Problem

Renovate is posting **"⚠️ Artifact update problem — you probably do not want to merge this PR"** on npm-manager PRs, e.g. [jdx/hk#1084](https://github.com/jdx/hk/pull/1084#issuecomment-5026303508):

```
Post-upgrade command '...aube install...' has not been added to the allowed list in allowedCommands
```

This corrects an assumption from #8: postUpgradeTasks **are** processed in this Renovate setup — they just require the command to be present in the bot's global `allowedCommands`/`allowedPostUpgradeCommands` allowlist, which isn't managed in these repos. So the rule fails on every npm bump and emits a scary "don't merge" comment across all repos extending this config.

(The pre-existing `mise lock` rule never surfaced this only because it's scoped to npm-backed *mise tool* bumps, which haven't occurred — it has the same latent failure.)

## Fix

Remove the aube `postUpgradeTasks` rule. The reusable **`aube-lock` workflow** (added in #8) already regenerates and commits the lockfile on `renovate/**` branches, needs no allowlist, and was **verified end-to-end** on hk#1084:

- renovate rebased → stale `aube-lock.yaml`
- workflow committed `chore(deps): regenerate aube-lock.yaml` (typescript → 7.0.2)
- push via the GitHub App token **retriggered CI** (a `GITHUB_TOKEN` push can't), and the self-run correctly skipped (sender-id gate)

So the rule is redundant; removing it stops the failure comments. `gitIgnoredAuthors` and the reusable workflow are kept.

## Follow-up (not in this PR)
The `mise lock` postUpgradeTask will fail identically once an npm-backed mise tool is bumped. Either add `mise lock` (and, if desired, the aube command) to the bot's `allowedPostUpgradeCommands`, or migrate it to the same workflow pattern.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that removes a broken Renovate hook; aube lockfile behavior is unchanged via the existing workflow.
> 
> **Overview**
> Removes the Renovate **package rule** that ran `aube install --no-frozen-lockfile` via **postUpgradeTasks** when npm dependencies changed.
> 
> That hook was failing on hosted Renovate because the command is not on the bot’s **allowedPostUpgradeCommands** list, which produced artifact-update warnings on npm bump PRs. **aube-lock.yaml** refresh is already handled by the reusable **aube-lock** GitHub workflow on `renovate/**` branches, so the rule was redundant.
> 
> The **mise lock** postUpgradeTasks rule and **gitIgnoredAuthors** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629c5316c7ce38f199ff1b2ad70f9ac03e280f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->